### PR TITLE
Bump webprotege-initial-revision-history-service to 1.0.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
 
 
   webprotege-initial-revision-history-service:
-    image: protegeproject/webprotege-initial-revision-history-service:1.0.4
+    image: protegeproject/webprotege-initial-revision-history-service:1.0.6
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
Upgraded the initial revision history service.  This service was not building properly because it was using the Spotify docker plugin.  I replaced this with the maven exec plugin.