### PR TITLE
Remove exposure of port 5000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,8 +317,6 @@ services:
     image: docker.elastic.co/logstash/logstash:8.12.2
     ports:
       - "5044:5044"
-      - "5000:5000/tcp"
-      - "5000:5000/udp"
       - "9600:9600"
     environment:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"


### PR DESCRIPTION
On a mac port 5000 is used for airdrop and is therefore taken.  I am not sure that this port needs to be exposed on the host anyway.  @alexsilaghi  please can you check this?